### PR TITLE
Moves shownoter functionality out of view

### DIFF
--- a/app/shownoter.py
+++ b/app/shownoter.py
@@ -7,6 +7,27 @@ from bs4 import BeautifulSoup
 from markdown import markdown
 
 
+def format_links_as_hash(source):
+
+    chat_links = link_detect(source)
+    links = []
+
+    for link in chat_links:
+
+        if image_detect(link):
+            link = Image(link)
+
+        else:
+            link = Link(link)
+
+        entry = {
+            'url':link.url,
+            'title':link.title,
+            'markdown':link.markdown}
+        links.append(entry)
+
+    return links
+
 def format_links_as_markdown(source):
     """ Wraps the shownoter functionality in a single function call """
     links = link_detect(source)
@@ -14,9 +35,11 @@ def format_links_as_markdown(source):
 
     for link in links:
         if image_detect(link):
-            urls.append(Image(link).markdown)
+            entry = Image(link)
         else:
-            urls.append(Link(link).markdown)
+            entry = Link(link)
+
+        urls.append(entry.markdown)
 
     output = links_to_string(urls)
     return output.strip()

--- a/unit_test.py
+++ b/unit_test.py
@@ -94,3 +94,14 @@ def test_image_markdown():
     title = ''
     assert '![](link.png)' in shownoter.image_markdown(title, link)
 
+# Test formatting functions
+
+def test_format_links_as_hash_returns_a_list_of_three_element_hashes(monkeypatch):
+    monkeypatch.setattr(shownoter, 'get', mock_get)
+
+    text = "link.com"
+    results = shownoter.format_links_as_hash(text)
+    assert 1 == len(results)
+    assert "* [Test](http://link.com)" == results[0]["markdown"]
+    assert "Test" == results[0]["title"]
+    assert "http://link.com" == results[0]["url"]


### PR DESCRIPTION
Moves the functionality in views.py that takes the links and parses them into a hash and puts it into the shownoter module.  This seems like core shownoter functionality rather than specific to the flask app.