### PR TITLE
Fixes AttributeError

### DIFF
--- a/app/shownoter.py
+++ b/app/shownoter.py
@@ -62,6 +62,9 @@ def image_detect(url):
     image_extension = ['.jpg', '.png', '.jpeg', '.gif']
     extension = re.search(r'\.[a-zA-Z]{2,}$', url, re.M)
 
+    if extension == None:
+        return False
+
     if extension.group(0) in image_extension:
         return True
 

--- a/test/test_shownoter.py
+++ b/test/test_shownoter.py
@@ -65,6 +65,10 @@ def test_image_detect_does_not_detect_outside_other_links():
     link = 'link.foo'
     assert not shownoter.image_detect(link)
 
+def test_image_detect_does_not_throw_attribute_error_when_no_extension():
+    link = 'https://gist.github.com/anonymous/7e5fa94f6e946551b70a'
+    assert not shownoter.image_detect(link)
+
 @requests_mock.Mocker(kw='mock')
 def test_title(mock_html, **kwargs):
     link = 'http://link.com'


### PR DESCRIPTION
shownoter.detect_image was raising an AttributeError when a link was
passed to it that did not have an extension.

This PR alters detect_link to simply return false in this case.