### PR TITLE
Updates to recover gracefully from pages without title

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,4 +5,4 @@ source = app
 
 [paths]
 source =
-    app/
+    test/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ Shownoter will take the chat above and output a formatted list with descriptions
 ## Logging Issues
 Please log any Shownoter issues [on the Trello board](https://trello.com/b/jlyUZ0ml/shownoter)
 
+### DNS forwarding
+Some ISPs will redirect invalid urls to a page that states that the url was not found along with other content.  This can affect the results that shownoter returns.
+
+Shownoter gathers the page title from the content of a page using the requests module.  If it performs a request and gets a result with a status code other than success (200) it will ignore the link considering it invalid.
+
+If you are receiving inconsistant results you may want to check to see if this is causing the issue.
+
 ## Requirements
 
 The following setion outlines the requirements for running shownoter.

--- a/README.md
+++ b/README.md
@@ -98,10 +98,8 @@ Linters do static analysis to find potential issues or style problems in the cod
 
 ### Testing coverage
 
-You can see how well the code is covered by tests using two commands.
+Test coverage can be determined using the pytest-cov plugin.  Use it as follows:
 
-First perform the coverage analysis:
-```coverage run unit_test.py```
-
-Next, output the summary results:
-```coverage report```
+```
+py.test --cov-report term-missing --cov=app test/
+```

--- a/README.md
+++ b/README.md
@@ -101,5 +101,5 @@ Linters do static analysis to find potential issues or style problems in the cod
 Test coverage can be determined using the pytest-cov plugin.  Use it as follows:
 
 ```
-py.test --cov-report term-missing --cov=app test/
+python -m pytest --cov-report term-missing --cov=app test/test_shownoter.py
 ```

--- a/app/shownoter.py
+++ b/app/shownoter.py
@@ -80,9 +80,16 @@ def image_detect(url):
 
     return False
 
-def parse_title(content):
+def parse_title(content, default_title=""):
     """Parses the title of a site from it's content"""
-    return BeautifulSoup(content, 'html.parser').title.text
+    if content == None:
+        return default_title
+
+    soup =  BeautifulSoup(content, 'html.parser')
+    if soup == None or soup.title == None:
+        return default_title
+
+    return soup.title.text
 
 def link_markdown(title, url):
     """Formats a generic link to a markdown list item link"""
@@ -140,7 +147,7 @@ class Link():
         """ Collects the various information about the link """
         self.site = valid_link(site)
         self.url =  self.site.url
-        self.title = parse_title(self.site.content)
+        self.title = parse_title(self.site.content) or site
         self.markdown = link_markdown(self.title, self.url)
 
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,5 +4,4 @@ coverage==4.0.3
 lazy-object-proxy==1.2.1
 pylint==1.5.1
 pytest==2.8.2
-requests-mock==0.6.0
 wrapt==1.10.6

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,4 +4,5 @@ coverage==4.0.3
 lazy-object-proxy==1.2.1
 pylint==1.5.1
 pytest==2.8.2
+pytest-cov==2.2.0
 wrapt==1.10.6

--- a/functional/test_alice_tests_markdown_list_output.py
+++ b/functional/test_alice_tests_markdown_list_output.py
@@ -2,14 +2,14 @@ from app import shownoter
 import pytest
 
 
-class ResultForTesting(object):
+def mock_url_homepage_result(url):
+    return UrlHomepageResult(url)
+
+class UrlHomepageResult(object):
     def __init__(self, url):
         self.status_code = 200
         self.url = url
         self.content = '<html><head><title>{} Homepage</title></head></html>'.format(url)
-
-def mock_get(url):
-    return ResultForTesting(url)
 
 @pytest.fixture(autouse=True)
 def mock_http(monkeypatch):
@@ -18,7 +18,7 @@ def mock_http(monkeypatch):
     that will emulate the results object that will generate a title of:
     "{url} Homepage"
     """
-    monkeypatch.setattr(shownoter, 'get', mock_get)
+    monkeypatch.setattr(shownoter, 'get', mock_url_homepage_result)
 
 def test_alice_generates_basic_shownotes():
     """

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -1,0 +1,37 @@
+""" This file contains fixtures and other functions used across multiple tests """
+
+import pytest
+
+
+@pytest.fixture
+def content():
+    return '<html><head><title>Test</title></head></html>'
+
+class GetResult(object):
+    def __init__(self, url):
+        self.status_code = 200
+        self.url = url
+        self.content = '<html><head><title>Test</title></head></html>'
+
+class GetResultNoTitle(object):
+    def __init__(self, url):
+        self.status_code = 200
+        self.url = url
+        self.content = '<html><head></head></html>'
+
+class GetNotFound(object):
+    def __init__(self, url):
+        self.status_code = 404
+
+def mock_get(url):
+    return GetResult(url)
+
+def mock_not_found(url):
+    return GetNotFound(url)
+
+def mock_requests_connection_error(url):
+    raise requests.exceptions.ConnectionError
+
+def mock_get_without_title(url):
+    return GetResultNoTitle(url)
+


### PR DESCRIPTION
* Shownoter will now use the url if the page comes back without a title element.
* Moved unit test helper functions and fixtures to their own file
* Removed dependency on requests-mock
* Adds 7 new unit tests
* Unit test coverage up to 67%

![shownoter-coverage](https://cloud.githubusercontent.com/assets/38428/11984424/b67cd680-a980-11e5-9957-d905a05f6e04.png)
