### PR TITLE
Updates the url finding regex to find the nose picking kid correctly

### DIFF
--- a/app/url_parser.py
+++ b/app/url_parser.py
@@ -1,6 +1,8 @@
 import csv
 import re
 
+re_url = r'''(?i)\b((?:https?:(?:\/{1,3}|[a-z0-9%])|[a-z0-9.\-]+[.](?:com|net|org|edu|gov|mil|aero|asia|biz|cat|coop|info|int|jobs|mobi|museum|name|post|pro|tel|travel|xxx|ac|ad|ae|af|ag|ai|al|am|an|ao|aq|ar|as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr|cs|cu|cv|cx|cy|cz|dd|de|dj|dk|dm|do|dz|ec|ee|eg|eh|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn|hr|ht|hu|id|ie|il|im|in|io|iq|ir|is|it|je|jm|jo|jp|ke|kg|kh|ki|km|kn|kp|kr|kw|ky|kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|ma|mc|md|me|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|na|nc|ne|nf|ng|ni|nl|no|np|nr|nu|nz|om|pa|pe|pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|re|ro|rs|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj|Ja|sk|sl|sm|sn|so|sr|ss|st|su|sv|sx|sy|sz|tc|td|tf|tg|th|tj|tk|tl|tm|tn|to|tp|tr|tt|tv|tw|tz|ua|ug|uk|us|uy|uz|va|vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|yu|za|zm|zw)\/)(?:[^\s()<>{}\[\]]+|\([^\s()]*?\([^\s()]+\)[^\s()]*?\)|\([^\s]+?\))+(?:\([^\s()]*?\([^\s()]+\)[^\s()]*?\)|\([^\s]+?\)|[^\s`!()\[\]{};:'".,<>?«»""''])|(?:(?<!@)[a-z0-9]+(?:[.\-][a-z0-9]+)*[.](?:com|net|org|edu|gov|mil|aero|asia|biz|cat|coop|info|int|jobs|mobi|museum|name|post|pro|tel|travel|xxx|ac|ad|ae|af|ag|ai|al|am|an|ao|aq|ar|as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr|cs|cu|cv|cx|cy|cz|dd|de|dj|dk|dm|do|dz|ec|ee|eg|eh|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn|hr|ht|hu|id|ie|il|im|in|io|iq|ir|is|it|je|jm|jo|jp|ke|kg|kh|ki|km|kn|kp|kr|kw|ky|kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|ma|mc|md|me|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|na|nc|ne|nf|ng|ni|nl|no|np|nr|nu|nz|om|pa|pe|pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|re|ro|rs|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj|Ja|sk|sl|sm|sn|so|sr|ss|st|su|sv|sx|sy|sz|tc|td|tf|tg|th|tj|tk|tl|tm|tn|to|tp|tr|tt|tv|tw|tz|ua|ug|uk|us|uy|uz|va|vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|yu|za|zm|zw)\b\/?(?!@)))'''
+
 with open('app/static/tlds.txt', 'r+') as f:
     top_level_domains = f.read().splitlines()
 
@@ -12,12 +14,12 @@ with open('app/static/uri-schemes-1.csv', newline='', encoding='utf-8') as csvfi
 
 def link_detect(content):
     """ Returns a list of urls from a import string"""
-    re_link = re.compile(r'(\b(\S+[:\.@]\/\/)*([\w\d]+[@\.][a-zA-Z]+\d*([@\/\w\.\?=]+)*))', re.M)
+    re_link = re.compile(re_url, re.M)
     links = []
 
     for link in re.findall(re_link, content):
-        if link[0] not in links:
-            links.append(link[0])
+        if link not in links:
+            links.append(link)
     return links
 
 def image_detect(url):

--- a/test/test_shownoter.py
+++ b/test/test_shownoter.py
@@ -250,6 +250,15 @@ def test_maintains_case(monkeypatch):
     assert "Test" == results[0]["title"]
     assert "https://www.youtube.com/watch?v=dQw4w9WgXcQ" == results[0]["url"]
 
+def test_image_is_generated_correctly(monkeypatch):
+    monkeypatch.setattr(shownoter, 'get', mock_get)
+
+    text = nose_pick_image_url
+    results = shownoter.format_links_as_hash(text)
+    assert 1 == len(results)
+    assert nose_pick_image_url in results[0]["markdown"]
+    assert nose_pick_image_url == results[0]["url"]
+
 def test_get_domain():
     urls = ['http://foo.com', 'http://www.foo.com', 'https://foo.com', 'ftp://foo.com', 'www.foo.com']
     for url in urls:

--- a/test/test_shownoter.py
+++ b/test/test_shownoter.py
@@ -6,6 +6,9 @@ import requests
 
 from test_helpers import *
 
+
+nose_pick_image_url = "http://i.kinja-img.com/gawker-media/image/upload/s--L1pCBzQp--/c_scale,fl_progressive,q_80,w_800/ysoqiqmpjisekm04i3zi.jpg"
+
 # Test link detection
 
 def test_link_detect_finds_one_link_text():
@@ -183,6 +186,9 @@ def test_image_detect_detects_gif():
 def test_image_detect_does_not_detect_outside_other_links():
     link = 'link.foo'
     assert not url_parser.image_detect(link)
+
+def test_image_detects_nose_picking():
+    assert url_parser.image_detect(nose_pick_image_url)
 
 def test_image_detect_does_not_throw_attribute_error_when_no_extension():
     link = 'https://gist.github.com/anonymous/7e5fa94f6e946551b70a'


### PR DESCRIPTION
I have updated to use the daring fireball url regex string.  This new regex pattern correctly identifies the url for the nose picking kid with the long and non-standard url.  It also includes about 100 of the most common top level domains.

Cons: I have no idea what it means, but on the upside I didn't know what the previous one meant either. 